### PR TITLE
Enabled builtin codec factory.

### DIFF
--- a/WebRTCPlugin/WebRTCProxy.cpp
+++ b/WebRTCPlugin/WebRTCProxy.cpp
@@ -121,8 +121,8 @@ HRESULT WebRTCProxy::FinalConstruct()
 			NULL,
 			webrtc::CreateBuiltinAudioEncoderFactory(),
 			webrtc::CreateBuiltinAudioDecoderFactory(),
-			//webrtc::CreateBuiltinVideoEncoderFactory(),
-			absl::make_unique<webrtc::H264VideoEncoderFactory>(),
+			webrtc::CreateBuiltinVideoEncoderFactory(),
+			//absl::make_unique<webrtc::H264VideoEncoderFactory>(),
 			webrtc::CreateBuiltinVideoDecoderFactory(),
 			NULL,
 			NULL


### PR DESCRIPTION
All codecs are now enabled, including VP8/9 and H264, encoders and decoders.